### PR TITLE
Clamp fence length in Markdown output

### DIFF
--- a/render.go
+++ b/render.go
@@ -98,6 +98,9 @@ func (r *Result) fence() string {
 			s = s[j:]
 		}
 	}
+	if longest > 16 {
+		longest = 16
+	}
 	return strings.Repeat("`", longest+1)
 }
 

--- a/render_test.go
+++ b/render_test.go
@@ -73,6 +73,37 @@ func TestXML(t *testing.T) {
 	}
 }
 
+func TestMarkdownFenceClamped(t *testing.T) {
+	r := &Result{
+		Files: []File{{Path: "x.md", Content: strings.Repeat("`", 1000) + "\ncode"}},
+	}
+	var b strings.Builder
+	if err := r.Markdown(&b); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	fence := strings.Repeat("`", 17)
+	// Check fence lines (fence+lang and closing fence), not content lines.
+	var foundOpen, foundClose bool
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, fence+"markdown") {
+			foundOpen = true
+			if strings.HasPrefix(line, fence+"`") {
+				t.Error("opening fence is longer than 17 backticks")
+			}
+		}
+		if line == fence {
+			foundClose = true
+		}
+	}
+	if !foundOpen {
+		t.Error("fence should be exactly 17 backticks (16 max + 1) for opening")
+	}
+	if !foundClose {
+		t.Error("fence should be exactly 17 backticks (16 max + 1) for closing")
+	}
+}
+
 func TestPackMarkdownEndToEnd(t *testing.T) {
 	root := setupRepo(t)
 	r, err := Pack(root, Options{Compress: true, MaxFileSize: 1000})


### PR DESCRIPTION
A file containing an arbitrarily long run of backticks causes `fence()` to pass that length to `strings.Repeat`, producing a proportionally large fence string in the Markdown output. This lets a hostile repository amplify output size.

The fix clamps `longest` to 16 before building the fence, so the fence is at most 17 backticks (16 + 1). Added `TestMarkdownFenceClamped` to verify the clamp works when content contains 1000 backticks.