### PR TITLE
Bump github.com/odvcencio/gotreesitter to 0.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/git-pkgs/outline
 
 go 1.25.6
 
-require github.com/odvcencio/gotreesitter v0.15.3
+require github.com/odvcencio/gotreesitter v0.18.0
 
 require github.com/git-pkgs/gitignore v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/git-pkgs/gitignore v1.1.2 h1:rWifE6a4QcnawUQzX6y/cFqX3LRD0y0mjtGaU5NWpek=
 github.com/git-pkgs/gitignore v1.1.2/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
-github.com/odvcencio/gotreesitter v0.15.3 h1:bcSIEMyRrDaFIZw2zwM8cNR03VX6y8CbXFxVzfFSGX0=
-github.com/odvcencio/gotreesitter v0.15.3/go.mod h1:ccYZsDUmAJQAtliLsNHT33F3X4AN7f/Z6JGiPNZoEzY=
+github.com/odvcencio/gotreesitter v0.18.0 h1:hYiUp3lFXlB+YEplv1KxRFM8IKAv1e5QcJcC3nKIsVI=
+github.com/odvcencio/gotreesitter v0.18.0/go.mod h1:MSmkQmznhGkdLcyQxiM813bi014e1Y1cpcDnm50meHs=


### PR DESCRIPTION
Supersedes #2.

Dependabot's bump to 0.16.0 fails `TestOutlineKotlin` because gotreesitter 0.16.0 shipped a regenerated Kotlin grammar that cannot lex the literal `.` token, so any Kotlin source with member access, qualified types, or a dotted `package` header parses to an `ERROR` root and the outline query matches nothing.

Upstream fixed this in `e6269c1` (`fix(kotlin): Restore Kotlin parsing after grammar bump`), first released in v0.17.1. Bumping straight to v0.18.0.