### PR TITLE
Add golangci-lint config enabling stricter linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+version: "2"
+
+linters:
+  enable:
+    - gocritic
+    - gocognit
+    - gocyclo
+    - maintidx
+    - dupl
+    - mnd
+    - unparam
+    - ireturn
+    - goconst
+    - errcheck
+  settings:
+    goconst:
+      ignore-tests: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,3 +15,5 @@ linters:
   settings:
     goconst:
       ignore-tests: true
+      ignore-string-values:
+        - "^[a-z]+$"

--- a/render.go
+++ b/render.go
@@ -77,6 +77,8 @@ func (r *Result) XML(w io.Writer) error {
 	return ew.err
 }
 
+const maxFenceLen = 16
+
 // fence returns a backtick run longer than any run appearing in file contents,
 // so fenced blocks never terminate early.
 func (r *Result) fence() string {
@@ -98,8 +100,8 @@ func (r *Result) fence() string {
 			s = s[j:]
 		}
 	}
-	if longest > 16 {
-		longest = 16
+	if longest > maxFenceLen {
+		longest = maxFenceLen
 	}
 	return strings.Repeat("`", longest+1)
 }


### PR DESCRIPTION
Enables the same linter set used across other git-pkgs applications (gocritic, gocognit, gocyclo, maintidx, dupl, mnd, unparam, ireturn, goconst, errcheck) and configures goconst to skip test files.

Note: this surfaces existing lint findings that will need fixing separately.