### PR TITLE
Bump github.com/odvcencio/gotreesitter to 0.20.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/git-pkgs/outline
 
 go 1.25.6
 
-require github.com/odvcencio/gotreesitter v0.18.0
+require github.com/odvcencio/gotreesitter v0.20.2
 
 require github.com/git-pkgs/gitignore v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/git-pkgs/gitignore v1.1.2 h1:rWifE6a4QcnawUQzX6y/cFqX3LRD0y0mjtGaU5NWpek=
 github.com/git-pkgs/gitignore v1.1.2/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
-github.com/odvcencio/gotreesitter v0.18.0 h1:hYiUp3lFXlB+YEplv1KxRFM8IKAv1e5QcJcC3nKIsVI=
-github.com/odvcencio/gotreesitter v0.18.0/go.mod h1:MSmkQmznhGkdLcyQxiM813bi014e1Y1cpcDnm50meHs=
+github.com/odvcencio/gotreesitter v0.20.2 h1:oWxGgy0WzLJKeiZB8EFzXDDlHYG/hqiZmWrW+81uwy4=
+github.com/odvcencio/gotreesitter v0.20.2/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=


### PR DESCRIPTION
Fixes a fatal stack overflow when outlining Python files containing `"""\` (triple-quoted string opener immediately followed by a line continuation). The repro is `pytorch/.github/scripts/lint_native_functions.py` — on v0.18.0 `normalizePythonStringContinuationEscapes` recurses on the same node without advancing and overflows the goroutine stack, taking the whole process down. The v0.19 Python normalizer rewrite removed that path; a full `Pack` of pytorch/pytorch now completes (21k files, ~18s).

No API changes needed on our side; all per-language golden tests pass unchanged.

Known trade-off: v0.19+ regresses on large table-driven Go test files — `spf13/cobra` `completions_test.go` parses fine on v0.18.0 but overflows in `normalizeGoCompatibility` on v0.20.2 (upstream [#110](https://github.com/odvcencio/gotreesitter/issues/110)). Upstream main has [#113](https://github.com/odvcencio/gotreesitter/pull/113) merged which turns the overflow into a multi-minute spin instead ([#114](https://github.com/odvcencio/gotreesitter/issues/114)), so not yet worth pinning past the tag. Taking the bump anyway since the Python crash is hit by real `brief outline` usage today and the Go one is narrower.