### PR TITLE
Bump github.com/odvcencio/gotreesitter from 0.20.6 to 0.20.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/git-pkgs/outline
 
 go 1.25.6
 
-require github.com/odvcencio/gotreesitter v0.20.6
+require github.com/odvcencio/gotreesitter v0.20.7
 
 require github.com/git-pkgs/gitignore v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/git-pkgs/gitignore v1.2.0 h1:7vdR8/SvF31dvXqIdC1bKgCvyySefXuN8aY3xJLuFaM=
 github.com/git-pkgs/gitignore v1.2.0/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
-github.com/odvcencio/gotreesitter v0.20.6 h1:tGq0vJwlpprxf5/2cfSVSo58dtvAj6/3Y39CjXtohbY=
-github.com/odvcencio/gotreesitter v0.20.6/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
+github.com/odvcencio/gotreesitter v0.20.7 h1:jHFHEt7z2tJ+XLXqFrl/cnmjDkJQWy+9OljYc5HE+a8=
+github.com/odvcencio/gotreesitter v0.20.7/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=


### PR DESCRIPTION
Bumps `gotreesitter` 0.20.6 -> 0.20.7, which fixes the F# external-scanner panic (slice bounds out of range) on unguarded indent-stack pops in the `then`/`and`/`with`/`else`/`elif`/`end` keyword dedent fallbacks (odvcencio/gotreesitter#129).

Verified against the dotnet/fsharp sources: 5276 `.fs` files now parse with zero panics, where 0.20.6 crashed on 8.