### PR TITLE
Disable parse timeout in tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,17 @@
+package outline
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain disables the per-file parse timeout for the test suite. The
+// timeout exists to keep pathological real-world inputs from dominating a
+// Pack run; test fixtures are tiny and should never hit it. On slow CI
+// runners (macOS under -race) the Swift grammar has been observed to brush
+// the 1s default and intermittently trip ParseStoppedEarly, turning a
+// correctness test into a timing test.
+func TestMain(m *testing.M) {
+	SetParseTimeout(0)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
`TestOutlineSwift` is flaky on `macos-latest` under `-race`: the Swift tree-sitter grammar is slow enough that parsing the 15-line fixture brushes the 1s `DefaultParseTimeout`, and runner jitter tips it into `ParseStoppedEarly()` → `Outline()` returns `ok=false` → test fails with `Sample.swift: not supported`.

Recent macOS timings for that test across CI runs: 0.87s, 0.87s, 1.01s, 1.29s, 1.34s, 1.47s (fail), 1.55s, 2.37s (fail). Main is currently red with this.

The timeout exists to keep pathological real-world inputs from dominating a `Pack` run; it has no business gating unit tests on tiny fixtures. Add a `TestMain` that calls `SetParseTimeout(0)` before the suite runs so correctness tests aren't also timing tests. The overall `go test` timeout still catches a genuine hang.