### PR TITLE
Bump github.com/odvcencio/gotreesitter from 0.21.0 to 0.45.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/git-pkgs/outline
 
 go 1.25.6
 
-require github.com/odvcencio/gotreesitter v0.21.0
+require github.com/odvcencio/gotreesitter v0.45.0
 
 require github.com/git-pkgs/gitignore v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/git-pkgs/gitignore v1.2.0 h1:7vdR8/SvF31dvXqIdC1bKgCvyySefXuN8aY3xJLuFaM=
 github.com/git-pkgs/gitignore v1.2.0/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
-github.com/odvcencio/gotreesitter v0.21.0 h1:ews6dnPac/UnMQ4PCTgxpUZb04I9fnEGKINmrHZuOpc=
-github.com/odvcencio/gotreesitter v0.21.0/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=
+github.com/odvcencio/gotreesitter v0.45.0 h1:tt1iWOfcFglz59BQyOz64z2H5XelucxkKK1Lyg0YesU=
+github.com/odvcencio/gotreesitter v0.45.0/go.mod h1:hBVkghd0paaYAVwd2087vfwdeU984bQbMo9LvpE0moo=


### PR DESCRIPTION
Manual bump ahead of dependabot's 7-day cooldown.

v0.22.0 through v0.44.x mis-parse TypeScript arrow functions with return-type annotations (`const f = (a: A): B => { ... }`), producing ERROR nodes and dropping those declarations from `.ts` outlines. Reported and fixed upstream in odvcencio/gotreesitter#402; the fix shipped in v0.45.0.

Supersedes #18.