### PR TITLE
Add symbol metadata to outlined files

### DIFF
--- a/outline.go
+++ b/outline.go
@@ -37,12 +37,13 @@ func SetParseTimeout(d time.Duration) {
 }
 
 type lang struct {
-	name  string
-	load  func() *ts.Language
-	pool  *ts.ParserPool
-	query *ts.Query
-	once  sync.Once
-	err   error
+	name     string
+	load     func() *ts.Language
+	language *ts.Language
+	pool     *ts.ParserPool
+	query    *ts.Query
+	once     sync.Once
+	err      error
 }
 
 func (l *lang) init() {
@@ -52,12 +53,12 @@ func (l *lang) init() {
 			l.err = err
 			return
 		}
-		tsLang := l.load()
-		l.query, l.err = ts.NewQuery(string(src), tsLang)
+		l.language = l.load()
+		l.query, l.err = ts.NewQuery(string(src), l.language)
 		if l.err != nil {
 			return
 		}
-		l.pool = ts.NewParserPool(tsLang, ts.WithParserPoolTimeoutMicros(parseTimeoutMicros))
+		l.pool = ts.NewParserPool(l.language, ts.WithParserPoolTimeoutMicros(parseTimeoutMicros))
 	})
 }
 
@@ -212,34 +213,47 @@ type chunk struct {
 // and comments are kept, function bodies are dropped. Returns the outline and
 // true if the file's language is supported, otherwise "", false.
 func Outline(src []byte, filename string) (string, bool) {
+	out, _, ok := outlineSource(src, filename, false)
+	return out, ok
+}
+
+func outlineFile(src []byte, filename string) (string, []Symbol, bool) {
+	return outlineSource(src, filename, true)
+}
+
+func outlineSource(src []byte, filename string, collectSymbols bool) (string, []Symbol, bool) {
 	l, ok := detect(filename)
 	if !ok {
-		return "", false
+		return "", nil, false
 	}
 	l.init()
 	if l.err != nil {
-		return "", false
+		return "", nil, false
 	}
 
 	tree, err := l.pool.Parse(src)
 	if err != nil || tree == nil {
-		return "", false
+		return "", nil, false
 	}
 	defer tree.Release()
 
 	if tree.ParseStoppedEarly() {
-		return "", false
+		return "", nil, false
 	}
 
 	lineStart, lineEnd := indexLines(src)
 	matches := l.query.Execute(tree)
+	var symbols []Symbol
+	if collectSymbols {
+		symbols = extractSymbols(src, l, tree.RootNode(), matches)
+	}
 
 	chunks := make([]chunk, 0, len(matches))
 	for _, m := range matches {
 		chunks = appendMatch(chunks, m, lineStart, lineEnd)
 	}
 	if len(chunks) == 0 {
-		return "", true
+		return "", symbols, true
 	}
 
 	sort.Slice(chunks, func(i, j int) bool {
@@ -260,7 +274,7 @@ func Outline(src []byte, filename string) (string, bool) {
 		}
 		b.Write(bytes.TrimRight(src[c.startOff:c.endOff], " \t\n"))
 	}
-	return b.String(), true
+	return b.String(), symbols, true
 }
 
 // appendMatch converts a query match into kept line ranges. Each @keep

--- a/pack.go
+++ b/pack.go
@@ -41,6 +41,7 @@ type File struct {
 	Content  string
 	Language string
 	Outlined bool
+	Symbols  []Symbol // populated when Outlined is true
 	Size     int64
 	Skipped  string // reason content was omitted, e.g. "binary", "too-large"
 }
@@ -208,10 +209,11 @@ func readFile(root, path string, opts Options) File {
 
 	if opts.Compress {
 		if l, ok := detect(path); ok {
-			if out, ok := Outline(data, path); ok {
+			if out, symbols, ok := outlineFile(data, path); ok {
 				f.Content = out
 				f.Outlined = true
 				f.Language = l.name
+				f.Symbols = symbols
 				return f
 			}
 		}

--- a/pack_test.go
+++ b/pack_test.go
@@ -69,6 +69,9 @@ func TestPack(t *testing.T) {
 		if strings.Contains(f.Content, "fmt.Printf") {
 			t.Error("main.go outline leaked body")
 		}
+		if !hasSymbol(f.Symbols, Symbol{Name: "SayHello", Kind: "func", Line: 31, Exported: true}) {
+			t.Errorf("main.go symbols = %#v", f.Symbols)
+		}
 	}
 
 	if f, ok := files["lib/user.rb"]; !ok || !f.Outlined {
@@ -117,6 +120,18 @@ func TestPackNoCompress(t *testing.T) {
 	if !strings.Contains(f.Content, "fmt.Printf") {
 		t.Error("full content should include body")
 	}
+	if len(f.Symbols) != 0 {
+		t.Errorf("symbols populated without outlining: %#v", f.Symbols)
+	}
+}
+
+func hasSymbol(symbols []Symbol, want Symbol) bool {
+	for _, symbol := range symbols {
+		if symbol == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestPackMaxFiles(t *testing.T) {

--- a/queries/bash.scm
+++ b/queries/bash.scm
@@ -13,3 +13,9 @@
     (#match? @_c "^(source|export|set|shopt|alias|declare|readonly|local)$")) @keep)
 (program
   (declaration_command) @keep)
+
+(function_definition
+  name: (word) @symbol.name) @symbol.func
+(program
+  (variable_assignment
+    name: (variable_name) @symbol.name) @symbol.var)

--- a/queries/c.scm
+++ b/queries/c.scm
@@ -17,3 +17,24 @@
 
 (function_definition
   body: (compound_statement) @body) @signature
+
+(preproc_def
+  name: (identifier) @symbol.name) @symbol.const
+(preproc_function_def
+  name: (identifier) @symbol.name) @symbol.func
+(type_definition
+  (type_identifier) @symbol.name) @symbol.type
+(struct_specifier
+  name: (type_identifier) @symbol.name) @symbol.type
+(union_specifier
+  name: (type_identifier) @symbol.name) @symbol.type
+(enum_specifier
+  name: (type_identifier) @symbol.name) @symbol.type
+(declaration
+  declarator: (identifier) @symbol.name) @symbol.var
+(declaration
+  declarator: (init_declarator
+    declarator: (identifier) @symbol.name)) @symbol.var
+(function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @symbol.name)) @symbol.func

--- a/queries/clojure.scm
+++ b/queries/clojure.scm
@@ -25,3 +25,24 @@
   .
   (sym_lit) @_head
   (#match? @_head "^(defn|defn-|defmacro|defmulti|defmethod|defprotocol|defrecord|deftype|definterface)$")) @keep
+
+(list_lit
+  .
+  (sym_lit) @_head
+  .
+  (sym_lit) @symbol.name
+  (#match? @_head "^(def|defonce|declare)$")) @symbol.var
+
+(list_lit
+  .
+  (sym_lit) @_head
+  .
+  (sym_lit) @symbol.name
+  (#match? @_head "^(defn|defn-|defmacro|defmulti|defmethod)$")) @symbol.func
+
+(list_lit
+  .
+  (sym_lit) @_head
+  .
+  (sym_lit) @symbol.name
+  (#match? @_head "^(defprotocol|defrecord|deftype|definterface)$")) @symbol.type

--- a/queries/cmake.scm
+++ b/queries/cmake.scm
@@ -15,3 +15,14 @@
   (if_condition) @signature)
 (source_file
   (foreach_loop) @signature)
+
+(function_def
+  (function_command
+    (argument_list
+      .
+      (argument) @symbol.name))) @symbol.func
+(macro_def
+  (macro_command
+    (argument_list
+      .
+      (argument) @symbol.name))) @symbol.func

--- a/queries/cpp.scm
+++ b/queries/cpp.scm
@@ -33,3 +33,26 @@
 
 (function_definition
   body: (compound_statement) @body) @signature
+
+(namespace_definition
+  name: (namespace_identifier) @symbol.name) @symbol.type
+(alias_declaration
+  name: (type_identifier) @symbol.name) @symbol.type
+(type_definition
+  (type_identifier) @symbol.name) @symbol.type
+(class_specifier
+  name: (type_identifier) @symbol.name) @symbol.class
+(struct_specifier
+  name: (type_identifier) @symbol.name) @symbol.type
+(union_specifier
+  name: (type_identifier) @symbol.name) @symbol.type
+(enum_specifier
+  name: (type_identifier) @symbol.name) @symbol.type
+(declaration
+  declarator: (identifier) @symbol.name) @symbol.var
+(declaration
+  declarator: (init_declarator
+    declarator: (identifier) @symbol.name)) @symbol.var
+(function_definition
+  declarator: (function_declarator
+    declarator: (identifier) @symbol.name)) @symbol.func

--- a/queries/crystal.scm
+++ b/queries/crystal.scm
@@ -20,3 +20,24 @@
 (call
   method: (identifier) @_m
   (#match? @_m "^(getter|setter|property|include|extend)$")) @keep
+
+(class_def
+  (constant) @symbol.name) @symbol.class
+(module_def
+  (constant) @symbol.name) @symbol.type
+(struct_def
+  (constant) @symbol.name) @symbol.type
+(enum_def
+  .
+  (constant) @symbol.name) @symbol.type
+(const_assign
+  (constant) @symbol.name) @symbol.const
+(alias
+  .
+  (constant) @symbol.name) @symbol.type
+(method_def
+  .
+  [(identifier) (constant)] @symbol.name) @symbol.func
+(abstract_method_def
+  .
+  [(identifier) (constant)] @symbol.name) @symbol.func

--- a/queries/csharp.scm
+++ b/queries/csharp.scm
@@ -32,3 +32,20 @@
   body: (block) @body) @signature
 (local_function_statement
   body: (block) @body) @signature
+
+(class_declaration
+  name: (identifier) @symbol.name) @symbol.class
+(struct_declaration
+  (identifier) @symbol.name) @symbol.type
+(record_declaration
+  (identifier) @symbol.name) @symbol.type
+(interface_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(enum_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(delegate_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(method_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(local_function_statement
+  name: (identifier) @symbol.name) @symbol.func

--- a/queries/d.scm
+++ b/queries/d.scm
@@ -22,3 +22,19 @@
   (function_body
     (block_statement) @body)) @signature
 (function_declaration) @keep
+
+(struct_declaration
+  (identifier) @symbol.name) @symbol.type
+(class_declaration
+  (identifier) @symbol.name) @symbol.class
+(interface_declaration
+  (identifier) @symbol.name) @symbol.type
+(union_declaration
+  (identifier) @symbol.name) @symbol.type
+(enum_declaration
+  (identifier) @symbol.name) @symbol.type
+(alias_declaration
+  (alias_initializer
+    (identifier) @symbol.name)) @symbol.type
+(function_declaration
+  (identifier) @symbol.name) @symbol.func

--- a/queries/dart.scm
+++ b/queries/dart.scm
@@ -20,3 +20,20 @@
 (getter_signature) @keep
 (setter_signature) @keep
 (type_alias) @keep
+
+(class_definition
+  name: (identifier) @symbol.name) @symbol.class
+(mixin_declaration
+  .
+  (mixin)
+  .
+  (identifier) @symbol.name) @symbol.type
+(extension_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(enum_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(type_alias
+  .
+  (type_identifier) @symbol.name) @symbol.type
+(function_signature
+  name: (identifier) @symbol.name) @symbol.func

--- a/queries/elixir.scm
+++ b/queries/elixir.scm
@@ -18,3 +18,18 @@
 (call
   target: (identifier) @_def
   (#match? @_def "^(def|defp|defmacro|defmacrop|defstruct|defexception|use|import|alias|require)$")) @keep
+
+(call
+  target: (identifier) @_def
+  (arguments
+    .
+    (alias) @symbol.name)
+  (#match? @_def "^(defmodule|defprotocol|defimpl)$")) @symbol.type
+
+(call
+  target: (identifier) @_def
+  (arguments
+    .
+    (call
+      target: (identifier) @symbol.name))
+  (#match? @_def "^(def|defp|defmacro|defmacrop|defguard|defguardp|defdelegate)$")) @symbol.func

--- a/queries/erlang.scm
+++ b/queries/erlang.scm
@@ -14,3 +14,13 @@
 (fun_decl
   (function_clause
     body: (clause_body) @body)) @signature
+
+(record_decl
+  name: (atom) @symbol.name) @symbol.type
+(type_alias
+  (type_name
+    (atom) @symbol.name)) @symbol.type
+(fun_decl
+  (function_clause
+    .
+    (atom) @symbol.name)) @symbol.func

--- a/queries/fsharp.scm
+++ b/queries/fsharp.scm
@@ -8,3 +8,22 @@
 (type_definition) @keep
 
 (declaration_expression) @keep
+
+(named_module
+  .
+  (long_identifier
+    (identifier) @symbol.name)) @symbol.type
+(module_defn
+  .
+  (identifier) @symbol.name) @symbol.type
+(type_definition
+  .
+  (_
+    (type_name
+      (identifier) @symbol.name))) @symbol.type
+(declaration_expression
+  (function_or_value_defn
+    (value_declaration_left
+      (identifier_pattern
+        (long_identifier_or_op
+          (identifier) @symbol.name))))) @symbol.var

--- a/queries/go.scm
+++ b/queries/go.scm
@@ -21,3 +21,18 @@
 
 (method_declaration
   !body) @keep
+
+(type_spec
+  name: (type_identifier) @symbol.name) @symbol.type
+(type_alias
+  name: (type_identifier) @symbol.name) @symbol.type
+
+(var_spec
+  (identifier) @symbol.name) @symbol.var
+(const_spec
+  (identifier) @symbol.name) @symbol.const
+
+(function_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(method_declaration
+  name: (field_identifier) @symbol.name) @symbol.func

--- a/queries/groovy.scm
+++ b/queries/groovy.scm
@@ -12,3 +12,10 @@
 (function_definition
   (closure) @body) @signature
 (function_declaration) @keep
+
+(class_definition
+  name: (identifier) @symbol.name) @symbol.class
+(function_definition
+  function: (identifier) @symbol.name) @symbol.func
+(function_declaration
+  function: (identifier) @symbol.name) @symbol.func

--- a/queries/haskell.scm
+++ b/queries/haskell.scm
@@ -21,3 +21,25 @@
   (match) @body) @signature
 (function
   (match) @body) @signature
+
+(data_type
+  .
+  (name) @symbol.name) @symbol.type
+(newtype
+  .
+  (name) @symbol.name) @symbol.type
+(type_synomym
+  .
+  (name) @symbol.name) @symbol.type
+(type_family
+  .
+  (name) @symbol.name) @symbol.type
+(class
+  .
+  (name) @symbol.name) @symbol.type
+(bind
+  .
+  (variable) @symbol.name) @symbol.var
+(function
+  .
+  (variable) @symbol.name) @symbol.func

--- a/queries/hcl.scm
+++ b/queries/hcl.scm
@@ -7,3 +7,29 @@
 
 (block
   (body) @body) @signature
+
+(block
+  .
+  (identifier) @_kind
+  .
+  (string_lit
+    (template_literal) @symbol.name)
+  (#match? @_kind "^(variable|output|locals)$")) @symbol.var
+
+(block
+  .
+  (identifier) @_kind
+  .
+  (string_lit)
+  .
+  (string_lit
+    (template_literal) @symbol.name)
+  (#match? @_kind "^(resource|data)$")) @symbol.type
+
+(block
+  .
+  (identifier) @_kind
+  .
+  (string_lit
+    (template_literal) @symbol.name)
+  (#match? @_kind "^(module|provider)$")) @symbol.type

--- a/queries/java.scm
+++ b/queries/java.scm
@@ -28,3 +28,16 @@
 
 (constructor_declaration
   body: (constructor_body) @body) @signature
+
+(class_declaration
+  name: (identifier) @symbol.name) @symbol.class
+(interface_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(enum_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(record_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(annotation_type_declaration
+  name: (identifier) @symbol.name) @symbol.type
+(method_declaration
+  name: (identifier) @symbol.name) @symbol.func

--- a/queries/javascript.scm
+++ b/queries/javascript.scm
@@ -21,3 +21,23 @@
   (variable_declarator
     value: (arrow_function
       body: (statement_block) @body))) @signature
+
+(class_declaration
+  name: (identifier) @symbol.name) @symbol.class
+(function_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(generator_function_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(method_definition
+  name: (property_identifier) @symbol.name) @symbol.func
+
+(lexical_declaration
+  "const"
+  (variable_declarator
+    name: (identifier) @symbol.name
+    value: (arrow_function))) @symbol.const
+(lexical_declaration
+  "let"
+  (variable_declarator
+    name: (identifier) @symbol.name
+    value: (arrow_function))) @symbol.var

--- a/queries/julia.scm
+++ b/queries/julia.scm
@@ -20,3 +20,33 @@
 (assignment
   (call_expression)
   (_)) @keep
+
+(module_definition
+  (identifier) @symbol.name) @symbol.type
+(struct_definition
+  (type_head
+    (identifier) @symbol.name)) @symbol.type
+(abstract_definition
+  (type_head
+    (identifier) @symbol.name)) @symbol.type
+(primitive_definition
+  (type_head
+    (identifier) @symbol.name)) @symbol.type
+(const_statement
+  (assignment
+    (identifier) @symbol.name)) @symbol.const
+(function_definition
+  (signature
+    (call_expression
+      .
+      (identifier) @symbol.name))) @symbol.func
+(macro_definition
+  (signature
+    (call_expression
+      .
+      (identifier) @symbol.name))) @symbol.func
+(assignment
+  .
+  (call_expression
+    .
+    (identifier) @symbol.name)) @symbol.func

--- a/queries/kotlin.scm
+++ b/queries/kotlin.scm
@@ -22,3 +22,19 @@
 (function_declaration) @keep
 
 (secondary_constructor) @keep
+
+(class_declaration
+  .
+  (type_identifier) @symbol.name) @symbol.class
+(object_declaration
+  .
+  (type_identifier) @symbol.name) @symbol.type
+(type_alias
+  .
+  (type_identifier) @symbol.name) @symbol.type
+(property_declaration
+  (variable_declaration
+    (simple_identifier) @symbol.name)) @symbol.var
+(function_declaration
+  .
+  (simple_identifier) @symbol.name) @symbol.func

--- a/queries/lua.scm
+++ b/queries/lua.scm
@@ -12,3 +12,16 @@
 
 (chunk (return_statement) @keep)
 (chunk (variable_declaration) @keep)
+
+(function_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(function_declaration
+  name: (dot_index_expression) @symbol.name) @symbol.func
+(function_declaration
+  name: (method_index_expression) @symbol.name) @symbol.func
+
+(chunk
+  (variable_declaration
+    (assignment_statement
+      (variable_list
+        (identifier) @symbol.name))) @symbol.var)

--- a/queries/make.scm
+++ b/queries/make.scm
@@ -8,3 +8,9 @@
 (rule
   (recipe) @body) @signature
 (rule) @keep
+
+(variable_assignment
+  name: (word) @symbol.name) @symbol.var
+(rule
+  (targets
+    (word) @symbol.name)) @symbol.func

--- a/queries/nim.scm
+++ b/queries/nim.scm
@@ -26,3 +26,78 @@
   body: (statement_list) @body) @signature
 (macro_declaration
   body: (statement_list) @body) @signature
+
+(type_section
+  (type_declaration
+    (type_symbol_declaration
+      (identifier) @symbol.name))) @symbol.type
+(type_section
+  (type_declaration
+    (type_symbol_declaration
+      (exported_symbol
+        (identifier) @symbol.name) @symbol.exported))) @symbol.type
+
+(const_section
+  (variable_declaration
+    (symbol_declaration_list
+      (symbol_declaration
+        (identifier) @symbol.name)))) @symbol.const
+(const_section
+  (variable_declaration
+    (symbol_declaration_list
+      (symbol_declaration
+        (exported_symbol
+          (identifier) @symbol.name) @symbol.exported)))) @symbol.const
+(var_section
+  (variable_declaration
+    (symbol_declaration_list
+      (symbol_declaration
+        (identifier) @symbol.name)))) @symbol.var
+(var_section
+  (variable_declaration
+    (symbol_declaration_list
+      (symbol_declaration
+        (exported_symbol
+          (identifier) @symbol.name) @symbol.exported)))) @symbol.var
+(let_section
+  (variable_declaration
+    (symbol_declaration_list
+      (symbol_declaration
+        (identifier) @symbol.name)))) @symbol.const
+(let_section
+  (variable_declaration
+    (symbol_declaration_list
+      (symbol_declaration
+        (exported_symbol
+          (identifier) @symbol.name) @symbol.exported)))) @symbol.const
+
+(proc_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(proc_declaration
+  name: (exported_symbol
+    (identifier) @symbol.name) @symbol.exported) @symbol.func
+(func_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(func_declaration
+  name: (exported_symbol
+    (identifier) @symbol.name) @symbol.exported) @symbol.func
+(method_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(method_declaration
+  name: (exported_symbol
+    (identifier) @symbol.name) @symbol.exported) @symbol.func
+(iterator_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(iterator_declaration
+  name: (exported_symbol
+    (identifier) @symbol.name) @symbol.exported) @symbol.func
+(template_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(template_declaration
+  name: (exported_symbol
+    (identifier) @symbol.name) @symbol.exported) @symbol.func
+(macro_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(macro_declaration
+  name: (exported_symbol
+    (identifier) @symbol.name) @symbol.exported) @symbol.func

--- a/queries/ocaml.scm
+++ b/queries/ocaml.scm
@@ -13,3 +13,26 @@
 
 (value_definition) @keep
 (class_definition) @keep
+
+(module_definition
+  (module_binding
+    (module_name) @symbol.name)) @symbol.type
+(module_type_definition
+  .
+  (module_type_name) @symbol.name) @symbol.type
+(type_definition
+  (type_binding
+    (type_constructor) @symbol.name)) @symbol.type
+(external
+  .
+  (value_name) @symbol.name) @symbol.func
+(value_definition
+  (let_binding
+    (value_name) @symbol.name
+    (parameter))) @symbol.func
+(value_definition
+  (let_binding
+    (value_name) @symbol.name)) @symbol.var
+(class_definition
+  (class_binding
+    (class_name) @symbol.name)) @symbol.class

--- a/queries/perl.scm
+++ b/queries/perl.scm
@@ -7,3 +7,6 @@
 
 (subroutine_declaration_statement
   body: (block) @body) @signature
+
+(subroutine_declaration_statement
+  name: (bareword) @symbol.name) @symbol.func

--- a/queries/php.scm
+++ b/queries/php.scm
@@ -23,3 +23,16 @@
 
 (function_definition
   body: (compound_statement) @body) @signature
+
+(class_declaration
+  name: (name) @symbol.name) @symbol.class
+(interface_declaration
+  name: (name) @symbol.name) @symbol.type
+(trait_declaration
+  name: (name) @symbol.name) @symbol.type
+(enum_declaration
+  name: (name) @symbol.name) @symbol.type
+(function_definition
+  name: (name) @symbol.name) @symbol.func
+(method_declaration
+  name: (name) @symbol.name) @symbol.func

--- a/queries/python.scm
+++ b/queries/python.scm
@@ -21,3 +21,11 @@
 (class_definition
   body: (block
     (string) @keep))
+
+(class_definition
+  name: (identifier) @symbol.name) @symbol.class
+(function_definition
+  name: (identifier) @symbol.name) @symbol.func
+(module
+  (assignment
+    left: (identifier) @symbol.name) @symbol.var)

--- a/queries/r.scm
+++ b/queries/r.scm
@@ -11,3 +11,10 @@
 (binary_operator
   lhs: (identifier)
   rhs: (_)) @keep
+
+(binary_operator
+  lhs: (identifier) @symbol.name
+  rhs: (function_definition)) @symbol.func
+(binary_operator
+  lhs: (identifier) @symbol.name
+  rhs: (_)) @symbol.var

--- a/queries/ruby.scm
+++ b/queries/ruby.scm
@@ -29,3 +29,14 @@
 (call
   method: (identifier) @_m
   (#match? @_m "^(require|require_relative|load|autoload|attr_reader|attr_writer|attr_accessor|include|extend|prepend)$")) @keep
+
+(assignment
+  left: (constant) @symbol.name) @symbol.const
+(class
+  name: (_) @symbol.name) @symbol.class
+(module
+  name: (_) @symbol.name) @symbol.type
+(method
+  name: [(identifier) (constant)] @symbol.name) @symbol.func
+(singleton_method
+  name: [(identifier) (constant)] @symbol.name) @symbol.func

--- a/queries/rust.scm
+++ b/queries/rust.scm
@@ -29,3 +29,24 @@
   body: (block) @body) @signature
 (function_item !body) @keep
 (function_signature_item) @keep
+
+(mod_item
+  name: (identifier) @symbol.name) @symbol.type
+(struct_item
+  name: (type_identifier) @symbol.name) @symbol.type
+(enum_item
+  name: (type_identifier) @symbol.name) @symbol.type
+(union_item
+  name: (type_identifier) @symbol.name) @symbol.type
+(type_item
+  name: (type_identifier) @symbol.name) @symbol.type
+(trait_item
+  name: (type_identifier) @symbol.name) @symbol.type
+(const_item
+  name: (identifier) @symbol.name) @symbol.const
+(static_item
+  name: (identifier) @symbol.name) @symbol.var
+(function_item
+  name: (identifier) @symbol.name) @symbol.func
+(function_signature_item
+  name: (identifier) @symbol.name) @symbol.func

--- a/queries/scala.scm
+++ b/queries/scala.scm
@@ -25,3 +25,22 @@
 (var_definition) @keep
 (type_definition) @keep
 (given_definition) @keep
+
+(class_definition
+  name: (identifier) @symbol.name) @symbol.class
+(trait_definition
+  name: (identifier) @symbol.name) @symbol.type
+(object_definition
+  name: (identifier) @symbol.name) @symbol.type
+(enum_definition
+  name: (identifier) @symbol.name) @symbol.type
+(function_definition
+  name: (identifier) @symbol.name) @symbol.func
+(function_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(val_definition
+  pattern: (identifier) @symbol.name) @symbol.const
+(var_definition
+  pattern: (identifier) @symbol.name) @symbol.var
+(type_definition
+  name: (type_identifier) @symbol.name) @symbol.type

--- a/queries/starlark.scm
+++ b/queries/starlark.scm
@@ -16,3 +16,10 @@
 
 (function_definition
   body: (block) @body) @signature
+
+(module
+  (expression_statement
+    (assignment
+      left: (identifier) @symbol.name) @symbol.var))
+(function_definition
+  name: (identifier) @symbol.name) @symbol.func

--- a/queries/swift.scm
+++ b/queries/swift.scm
@@ -25,3 +25,23 @@
   body: (function_body) @body) @signature
 (deinit_declaration
   body: (function_body) @body) @signature
+
+(class_declaration
+  (modifiers)?
+  .
+  (type_identifier) @symbol.name) @symbol.class
+(protocol_declaration
+  (modifiers)?
+  .
+  (type_identifier) @symbol.name) @symbol.type
+(typealias_declaration
+  (modifiers)?
+  .
+  (type_identifier) @symbol.name) @symbol.type
+(property_declaration
+  (pattern
+    (simple_identifier) @symbol.name)) @symbol.var
+(function_declaration
+  (modifiers)?
+  .
+  (simple_identifier) @symbol.name) @symbol.func

--- a/queries/typescript.scm
+++ b/queries/typescript.scm
@@ -34,3 +34,34 @@
   (variable_declarator
     value: (arrow_function
       body: (statement_block) @body))) @signature
+
+(interface_declaration
+  (type_identifier) @symbol.name) @symbol.type
+(type_alias_declaration
+  (type_identifier) @symbol.name) @symbol.type
+(enum_declaration
+  (identifier) @symbol.name) @symbol.type
+(function_signature
+  (identifier) @symbol.name) @symbol.func
+
+(class_declaration
+  name: (type_identifier) @symbol.name) @symbol.class
+(abstract_class_declaration
+  name: (type_identifier) @symbol.name) @symbol.class
+(function_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(generator_function_declaration
+  name: (identifier) @symbol.name) @symbol.func
+(method_definition
+  name: (property_identifier) @symbol.name) @symbol.func
+
+(lexical_declaration
+  "const"
+  (variable_declarator
+    name: (identifier) @symbol.name
+    value: (arrow_function))) @symbol.const
+(lexical_declaration
+  "let"
+  (variable_declarator
+    name: (identifier) @symbol.name
+    value: (arrow_function))) @symbol.var

--- a/queries/zig.scm
+++ b/queries/zig.scm
@@ -16,3 +16,9 @@
 
 (test_declaration
   body: (block) @body) @signature
+
+(variable_declaration
+  .
+  (identifier) @symbol.name) @symbol.var
+(function_declaration
+  name: (identifier) @symbol.name) @symbol.func

--- a/symbol.go
+++ b/symbol.go
@@ -1,0 +1,422 @@
+package outline
+
+import (
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	ts "github.com/odvcencio/gotreesitter"
+)
+
+// Symbol is a top-level declaration captured while outlining a file.
+type Symbol struct {
+	Name     string
+	Kind     string // func, type, class, const, or var
+	Line     int    // one-based source line
+	Exported bool
+}
+
+type parsedSymbol struct {
+	Symbol
+	start uint32
+}
+
+func extractSymbols(src []byte, l *lang, root *ts.Node, matches []ts.QueryMatch) []Symbol {
+	parsed := make([]parsedSymbol, 0)
+	for _, match := range matches {
+		parsed = append(parsed, symbolsFromMatch(src, l, match)...)
+	}
+
+	applyExplicitExports(parsed, l, root, src)
+
+	sort.SliceStable(parsed, func(i, j int) bool {
+		return parsed[i].start < parsed[j].start
+	})
+	return deduplicateSymbols(parsed)
+}
+
+func symbolsFromMatch(src []byte, l *lang, match ts.QueryMatch) []parsedSymbol {
+	var definition *ts.Node
+	var kind string
+	exported := false
+	names := make([]*ts.Node, 0, 1)
+	for _, capture := range match.Captures {
+		switch capture.Name {
+		case "symbol.name":
+			names = append(names, capture.Node)
+		case "symbol.exported":
+			exported = true
+		case "symbol.func", "symbol.type", "symbol.class", "symbol.const", "symbol.var":
+			definition = capture.Node
+			kind = strings.TrimPrefix(capture.Name, "symbol.")
+		}
+	}
+	if definition == nil || kind == "" || !topLevelSymbol(definition, l.language) {
+		return nil
+	}
+
+	parsed := make([]parsedSymbol, 0, len(names))
+	for _, nameNode := range names {
+		if nameNode == nil {
+			continue
+		}
+		name := strings.TrimSpace(nameNode.Text(src))
+		if name == "" || name == "_" {
+			continue
+		}
+		parsed = append(parsed, parsedSymbol{
+			Symbol: Symbol{
+				Name:     name,
+				Kind:     normalizeSymbolKind(l.name, kind, name, definition, src, l.language),
+				Line:     int(nameNode.StartPoint().Row) + 1,
+				Exported: exported || symbolExported(l.name, name, definition, src, l.language),
+			},
+			start: nameNode.StartByte(),
+		})
+	}
+	return parsed
+}
+
+func applyExplicitExports(parsed []parsedSymbol, l *lang, root *ts.Node, src []byte) {
+	var exported map[string]bool
+	merge := false
+	switch l.name {
+	case "javascript", "typescript":
+		exported = javascriptExports(root, src, l.language)
+		merge = true
+	case "erlang":
+		exported = exportsFromNodes(root, src, l.language, "export_attribute", "export_type_attribute", "atom")
+	case "julia":
+		exported = exportsFromNodes(root, src, l.language, "export_statement", "public_statement", "identifier")
+	default:
+		return
+	}
+	for i := range parsed {
+		if merge {
+			parsed[i].Exported = parsed[i].Exported || exported[parsed[i].Name]
+		} else {
+			parsed[i].Exported = exported[parsed[i].Name]
+		}
+	}
+}
+
+func deduplicateSymbols(parsed []parsedSymbol) []Symbol {
+	type symbolKey struct {
+		name string
+		line int
+	}
+	seen := make(map[symbolKey]int, len(parsed))
+	symbols := make([]Symbol, 0, len(parsed))
+	for _, item := range parsed {
+		key := symbolKey{name: item.Name, line: item.Line}
+		if index, ok := seen[key]; ok {
+			symbols[index].Exported = symbols[index].Exported || item.Exported
+			if symbolKindRank(item.Kind) > symbolKindRank(symbols[index].Kind) {
+				symbols[index].Kind = item.Kind
+			}
+			continue
+		}
+		seen[key] = len(symbols)
+		symbols = append(symbols, item.Symbol)
+	}
+	return symbols
+}
+
+func topLevelSymbol(node *ts.Node, language *ts.Language) bool {
+	for parent := node.Parent(); parent != nil; parent = parent.Parent() {
+		if parent.Parent() == nil {
+			return true
+		}
+		switch parent.Type(language) {
+		case "ambient_declaration", "body", "const_declaration", "declarations", "decorated_definition", "export_statement", "expression_statement", "named_module", "template_declaration", "type_declaration", "var_declaration":
+			continue
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func symbolExported(language, name string, definition *ts.Node, src []byte, grammar *ts.Language) bool {
+	text := strings.TrimSpace(definition.Text(src))
+	switch language {
+	case "go":
+		r, _ := utf8.DecodeRuneInString(name)
+		return unicode.IsUpper(r)
+	case "javascript", "typescript":
+		return ancestorType(definition, "export_statement", grammar)
+	case "python", "dart", "starlark":
+		return !strings.HasPrefix(name, "_")
+	case "rust", "zig":
+		return startsWithWord(text, "pub") && !strings.HasPrefix(text, "pub(")
+	case "java", "csharp":
+		return containsWord(text, "public")
+	case "swift":
+		return containsWord(text, "public") || containsWord(text, "open")
+	case "elixir":
+		return startsWithWord(text, "defmodule") ||
+			startsWithWord(text, "defprotocol") ||
+			startsWithWord(text, "defimpl") ||
+			startsWithWord(text, "def") &&
+				!startsWithWord(text, "defp") &&
+				!startsWithWord(text, "defmacrop") &&
+				!startsWithWord(text, "defguardp")
+	case "clojure":
+		return !strings.HasPrefix(text, "(defn-")
+	case "nim":
+		return false
+	case "kotlin", "scala", "d", "fsharp", "groovy":
+		return !containsWord(text, "private") &&
+			!containsWord(text, "protected") &&
+			!containsWord(text, "internal")
+	case "c", "cpp":
+		return !containsWord(text, "static")
+	case "julia", "erlang":
+		return false
+	default:
+		return true
+	}
+}
+
+func normalizeSymbolKind(language, kind, name string, definition *ts.Node, src []byte, grammar *ts.Language) string {
+	text := strings.TrimSpace(definition.Text(src))
+	switch language {
+	case "kotlin":
+		return normalizeKotlinKind(kind, text)
+	case "swift":
+		return normalizeSwiftKind(kind, text)
+	case "zig":
+		return normalizeZigKind(kind, text, definition, grammar)
+	case "fsharp":
+		return normalizeFSharpKind(kind, name, text)
+	}
+	return kind
+}
+
+func normalizeKotlinKind(kind, text string) string {
+	if kind == "class" && (containsWord(text, "interface") || containsWord(text, "enum")) {
+		return "type"
+	}
+	if kind == "var" && containsWord(text, "val") {
+		return "const"
+	}
+	return kind
+}
+
+func normalizeSwiftKind(kind, text string) string {
+	if kind == "class" && (containsWord(text, "struct") || containsWord(text, "enum")) {
+		return "type"
+	}
+	if kind == "var" && containsWord(text, "let") {
+		return "const"
+	}
+	return kind
+}
+
+func normalizeZigKind(kind, text string, definition *ts.Node, grammar *ts.Language) string {
+	if kind != "var" {
+		return kind
+	}
+	if hasDescendantType(definition, grammar, "struct_declaration", "enum_declaration", "union_declaration", "opaque_declaration") {
+		return "type"
+	}
+	if containsWord(text, "const") {
+		return "const"
+	}
+	return kind
+}
+
+func normalizeFSharpKind(kind, name, text string) string {
+	if kind != "var" {
+		return kind
+	}
+	beforeEquals, _, _ := strings.Cut(text, "=")
+	index := strings.Index(beforeEquals, name)
+	if index < 0 {
+		return kind
+	}
+	remainder := strings.TrimSpace(beforeEquals[index+len(name):])
+	if remainder != "" && !strings.HasPrefix(remainder, ":") {
+		return "func"
+	}
+	return kind
+}
+
+func symbolKindRank(kind string) int {
+	const definitionRank = 2
+	switch kind {
+	case "func", "type", "class":
+		return definitionRank
+	case "const":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func hasDescendantType(node *ts.Node, language *ts.Language, types ...string) bool {
+	if node == nil {
+		return false
+	}
+	wanted := make(map[string]bool, len(types))
+	for _, nodeType := range types {
+		wanted[nodeType] = true
+	}
+	var visit func(*ts.Node) bool
+	visit = func(current *ts.Node) bool {
+		if wanted[current.Type(language)] {
+			return true
+		}
+		for i := range current.NamedChildCount() {
+			if visit(current.NamedChild(i)) {
+				return true
+			}
+		}
+		return false
+	}
+	return visit(node)
+}
+
+func ancestorType(node *ts.Node, want string, language *ts.Language) bool {
+	if language == nil {
+		return false
+	}
+	for parent := node.Parent(); parent != nil; parent = parent.Parent() {
+		if parent.Type(language) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func startsWithWord(text, word string) bool {
+	if !strings.HasPrefix(text, word) {
+		return false
+	}
+	return len(text) == len(word) || !isIdentifierByte(text[len(word)])
+}
+
+func containsWord(text, word string) bool {
+	for i := 0; i+len(word) <= len(text); i++ {
+		if text[i:i+len(word)] != word {
+			continue
+		}
+		if i > 0 && isIdentifierByte(text[i-1]) {
+			continue
+		}
+		if i+len(word) < len(text) && isIdentifierByte(text[i+len(word)]) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func isIdentifierByte(b byte) bool {
+	return b == '_' || b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z' || b >= '0' && b <= '9'
+}
+
+func javascriptExports(root *ts.Node, src []byte, language *ts.Language) map[string]bool {
+	exported := make(map[string]bool)
+	if root == nil {
+		return exported
+	}
+	for i := range root.NamedChildCount() {
+		node := root.NamedChild(i)
+		switch node.Type(language) {
+		case "export_statement":
+			collectJavascriptExportStatement(exported, node, src, language)
+		case "expression_statement":
+			collectCommonJSExport(exported, node, src, language)
+		}
+	}
+	return exported
+}
+
+func collectJavascriptExportStatement(exported map[string]bool, node *ts.Node, src []byte, language *ts.Language) {
+	if hasDirectChildType(node, "string", language) {
+		return
+	}
+	for i := range node.NamedChildCount() {
+		child := node.NamedChild(i)
+		switch child.Type(language) {
+		case "identifier":
+			exported[child.Text(src)] = true
+		case "export_clause":
+			for j := range child.NamedChildCount() {
+				specifier := child.NamedChild(j)
+				if specifier.NamedChildCount() > 0 {
+					exported[specifier.NamedChild(0).Text(src)] = true
+				}
+			}
+		}
+	}
+}
+
+func collectCommonJSExport(exported map[string]bool, statement *ts.Node, src []byte, language *ts.Language) {
+	if statement.NamedChildCount() == 0 {
+		return
+	}
+	assignment := statement.NamedChild(0)
+	if assignment.Type(language) != "assignment_expression" || assignment.NamedChildCount() < 2 {
+		return
+	}
+	left := strings.ReplaceAll(assignment.NamedChild(0).Text(src), " ", "")
+	if left != "module.exports" && !strings.HasPrefix(left, "module.exports.") && !strings.HasPrefix(left, "exports.") {
+		return
+	}
+	collectJavascriptExportValue(exported, assignment.NamedChild(1), src, language)
+}
+
+func collectJavascriptExportValue(exported map[string]bool, value *ts.Node, src []byte, language *ts.Language) {
+	switch value.Type(language) {
+	case "identifier", "shorthand_property_identifier":
+		exported[value.Text(src)] = true
+	case "object":
+		for i := range value.NamedChildCount() {
+			child := value.NamedChild(i)
+			switch child.Type(language) {
+			case "shorthand_property_identifier":
+				exported[child.Text(src)] = true
+			case "pair":
+				if child.NamedChildCount() > 1 {
+					collectJavascriptExportValue(exported, child.NamedChild(1), src, language)
+				}
+			}
+		}
+	}
+}
+
+func hasDirectChildType(node *ts.Node, want string, language *ts.Language) bool {
+	for i := range node.NamedChildCount() {
+		if node.NamedChild(i).Type(language) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func exportsFromNodes(root *ts.Node, src []byte, language *ts.Language, statementType, alternateType, nameType string) map[string]bool {
+	exported := make(map[string]bool)
+	if root == nil {
+		return exported
+	}
+	var collectNames func(*ts.Node)
+	collectNames = func(node *ts.Node) {
+		if node.Type(language) == nameType {
+			exported[node.Text(src)] = true
+			return
+		}
+		for i := range node.NamedChildCount() {
+			collectNames(node.NamedChild(i))
+		}
+	}
+	for i := range root.NamedChildCount() {
+		node := root.NamedChild(i)
+		if node.Type(language) == statementType || node.Type(language) == alternateType {
+			collectNames(node)
+		}
+	}
+	return exported
+}

--- a/symbol_test.go
+++ b/symbol_test.go
@@ -1,0 +1,477 @@
+package outline
+
+import (
+	"reflect"
+	"testing"
+)
+
+func symbolsFor(t *testing.T, filename, src string) []Symbol {
+	t.Helper()
+	_, symbols, ok := outlineFile([]byte(src), filename)
+	if !ok {
+		t.Fatalf("%s: not supported", filename)
+	}
+	return symbols
+}
+
+func TestGoSymbols(t *testing.T) {
+	src := `package sample
+
+type Public struct{}
+type private = int
+type (
+	Other int
+	hidden string
+)
+
+const PublicConst = 1
+const privateConst = 2
+var PublicVar, privateVar = 1, 2
+
+func PublicFunc() {
+	var local int
+}
+
+func privateFunc() {}
+func (Public) Method() {}
+`
+	want := []Symbol{
+		{Name: "Public", Kind: "type", Line: 3, Exported: true},
+		{Name: "private", Kind: "type", Line: 4},
+		{Name: "Other", Kind: "type", Line: 6, Exported: true},
+		{Name: "hidden", Kind: "type", Line: 7},
+		{Name: "PublicConst", Kind: "const", Line: 10, Exported: true},
+		{Name: "privateConst", Kind: "const", Line: 11},
+		{Name: "PublicVar", Kind: "var", Line: 12, Exported: true},
+		{Name: "privateVar", Kind: "var", Line: 12},
+		{Name: "PublicFunc", Kind: "func", Line: 14, Exported: true},
+		{Name: "privateFunc", Kind: "func", Line: 18},
+		{Name: "Method", Kind: "func", Line: 19, Exported: true},
+	}
+	if got := symbolsFor(t, "sample.go", src); !reflect.DeepEqual(got, want) {
+		t.Errorf("symbols = %#v, want %#v", got, want)
+	}
+}
+
+func TestJavascriptSymbols(t *testing.T) {
+	src := `export class PublicClass {}
+class LocalClass {}
+export function publicFunc() {}
+function localFunc() {}
+export const direct = () => {};
+const named = () => {};
+export { named };
+const common = () => {};
+module.exports.common = common;
+const objectValue = () => {};
+module.exports = { objectValue };
+class Container { method() {} }
+`
+	want := []Symbol{
+		{Name: "PublicClass", Kind: "class", Line: 1, Exported: true},
+		{Name: "LocalClass", Kind: "class", Line: 2},
+		{Name: "publicFunc", Kind: "func", Line: 3, Exported: true},
+		{Name: "localFunc", Kind: "func", Line: 4},
+		{Name: "direct", Kind: "const", Line: 5, Exported: true},
+		{Name: "named", Kind: "const", Line: 6, Exported: true},
+		{Name: "common", Kind: "const", Line: 8, Exported: true},
+		{Name: "objectValue", Kind: "const", Line: 10, Exported: true},
+		{Name: "Container", Kind: "class", Line: 12},
+	}
+	if got := symbolsFor(t, "sample.js", src); !reflect.DeepEqual(got, want) {
+		t.Errorf("symbols = %#v, want %#v", got, want)
+	}
+}
+
+func TestPythonSymbols(t *testing.T) {
+	src := `class Public:
+    field = 1
+
+class _Private:
+    pass
+
+def public_func():
+    def nested():
+        pass
+
+def _private_func():
+    pass
+
+PUBLIC_VALUE = 1
+_private_value = 2
+`
+	want := []Symbol{
+		{Name: "Public", Kind: "class", Line: 1, Exported: true},
+		{Name: "_Private", Kind: "class", Line: 4},
+		{Name: "public_func", Kind: "func", Line: 7, Exported: true},
+		{Name: "_private_func", Kind: "func", Line: 11},
+		{Name: "PUBLIC_VALUE", Kind: "var", Line: 14, Exported: true},
+		{Name: "_private_value", Kind: "var", Line: 15},
+	}
+	if got := symbolsFor(t, "sample.py", src); !reflect.DeepEqual(got, want) {
+		t.Errorf("symbols = %#v, want %#v", got, want)
+	}
+}
+
+func TestTypescriptSymbols(t *testing.T) {
+	src := `export interface PublicType {}
+type LocalType = string;
+enum LocalEnum { Value }
+declare function declared(): void;
+export abstract class PublicClass {}
+export const make = () => {};
+`
+	want := []Symbol{
+		{Name: "PublicType", Kind: "type", Line: 1, Exported: true},
+		{Name: "LocalType", Kind: "type", Line: 2},
+		{Name: "LocalEnum", Kind: "type", Line: 3},
+		{Name: "declared", Kind: "func", Line: 4},
+		{Name: "PublicClass", Kind: "class", Line: 5, Exported: true},
+		{Name: "make", Kind: "const", Line: 6, Exported: true},
+	}
+	if got := symbolsFor(t, "sample.ts", src); !reflect.DeepEqual(got, want) {
+		t.Errorf("symbols = %#v, want %#v", got, want)
+	}
+}
+
+func TestLanguageSymbolsCommon(t *testing.T) {
+	cases := []struct {
+		filename string
+		src      string
+		want     []Symbol
+	}{
+		{
+			filename: "sample.c",
+			src:      "#define MAX 1\nstruct User {};\ntypedef int ID;\nint value;\nstatic int hidden;\nint run(void) {}\n",
+			want: []Symbol{
+				{Name: "MAX", Kind: "const", Line: 1, Exported: true},
+				{Name: "User", Kind: "type", Line: 2, Exported: true},
+				{Name: "ID", Kind: "type", Line: 3, Exported: true},
+				{Name: "value", Kind: "var", Line: 4, Exported: true},
+				{Name: "hidden", Kind: "var", Line: 5},
+				{Name: "run", Kind: "func", Line: 6, Exported: true},
+			},
+		},
+		{
+			filename: "sample.cpp",
+			src:      "namespace app {}\nclass Widget {};\nstruct Value {};\nusing ID = int;\nint count;\nint run() {}\n",
+			want: []Symbol{
+				{Name: "app", Kind: "type", Line: 1, Exported: true},
+				{Name: "Widget", Kind: "class", Line: 2, Exported: true},
+				{Name: "Value", Kind: "type", Line: 3, Exported: true},
+				{Name: "ID", Kind: "type", Line: 4, Exported: true},
+				{Name: "count", Kind: "var", Line: 5, Exported: true},
+				{Name: "run", Kind: "func", Line: 6, Exported: true},
+			},
+		},
+		{
+			filename: "Sample.cs",
+			src:      "public class User {}\ninternal interface Hidden {}\npublic struct Value {}\npublic enum Color { Red }\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "Hidden", Kind: "type", Line: 2},
+				{Name: "Value", Kind: "type", Line: 3, Exported: true},
+				{Name: "Color", Kind: "type", Line: 4, Exported: true},
+			},
+		},
+		{
+			filename: "Sample.java",
+			src:      "public class User {}\ninterface Hidden {}\nenum Color { RED }\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "Hidden", Kind: "type", Line: 2},
+				{Name: "Color", Kind: "type", Line: 3},
+			},
+		},
+		{
+			filename: "sample.php",
+			src:      "<?php\nclass User {}\ninterface Greeter {}\nfunction helper() {}\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 2, Exported: true},
+				{Name: "Greeter", Kind: "type", Line: 3, Exported: true},
+				{Name: "helper", Kind: "func", Line: 4, Exported: true},
+			},
+		},
+		{
+			filename: "sample.rs",
+			src:      "pub struct User;\nconst HIDDEN: usize = 1;\npub fn run() {}\n",
+			want: []Symbol{
+				{Name: "User", Kind: "type", Line: 1, Exported: true},
+				{Name: "HIDDEN", Kind: "const", Line: 2},
+				{Name: "run", Kind: "func", Line: 3, Exported: true},
+			},
+		},
+		{
+			filename: "Sample.scala",
+			src:      "class User\ntrait Greeter\nobject Main\ntype ID = String\nval count = 1\nvar mutable = 2\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "Greeter", Kind: "type", Line: 2, Exported: true},
+				{Name: "Main", Kind: "type", Line: 3, Exported: true},
+				{Name: "ID", Kind: "type", Line: 4, Exported: true},
+				{Name: "count", Kind: "const", Line: 5, Exported: true},
+				{Name: "mutable", Kind: "var", Line: 6, Exported: true},
+			},
+		},
+		{
+			filename: "sample.dart",
+			src:      "class User {}\nmixin Shared {}\nenum Color { red }\ntypedef ID = String;\nvoid main() {}\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "Shared", Kind: "type", Line: 2, Exported: true},
+				{Name: "Color", Kind: "type", Line: 3, Exported: true},
+				{Name: "ID", Kind: "type", Line: 4, Exported: true},
+				{Name: "main", Kind: "func", Line: 5, Exported: true},
+			},
+		},
+		{
+			filename: "sample.d",
+			src:      "struct User {}\nclass Service {}\nalias ID = int;\nvoid run() {}\n",
+			want: []Symbol{
+				{Name: "User", Kind: "type", Line: 1, Exported: true},
+				{Name: "Service", Kind: "class", Line: 2, Exported: true},
+				{Name: "ID", Kind: "type", Line: 3, Exported: true},
+				{Name: "run", Kind: "func", Line: 4, Exported: true},
+			},
+		},
+		{
+			filename: "Sample.groovy",
+			src:      "class User {}\ndef main() {}\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "main", Kind: "func", Line: 2, Exported: true},
+			},
+		},
+		{
+			filename: "sample.sh",
+			src:      "VERSION=1\ngreet() { :; }\n",
+			want: []Symbol{
+				{Name: "VERSION", Kind: "var", Line: 1, Exported: true},
+				{Name: "greet", Kind: "func", Line: 2, Exported: true},
+			},
+		},
+		{
+			filename: "CMakeLists.txt",
+			src:      "function(greet name)\nendfunction()\nmacro(build target)\nendmacro()\n",
+			want: []Symbol{
+				{Name: "greet", Kind: "func", Line: 1, Exported: true},
+				{Name: "build", Kind: "func", Line: 3, Exported: true},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.filename, func(t *testing.T) {
+			if got := symbolsFor(t, tc.filename, tc.src); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("symbols = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLanguageSymbolsAdditional(t *testing.T) {
+	cases := []struct {
+		filename string
+		src      string
+		want     []Symbol
+	}{
+		{
+			filename: "sample.cr",
+			src:      "class User\nend\nmodule Tools\nend\nstruct Value\nend\nenum Color\n Red\nend\nMAX = 1\nalias ID = Int32\ndef run\nend\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "Tools", Kind: "type", Line: 3, Exported: true},
+				{Name: "Value", Kind: "type", Line: 5, Exported: true},
+				{Name: "Color", Kind: "type", Line: 7, Exported: true},
+				{Name: "MAX", Kind: "const", Line: 10, Exported: true},
+				{Name: "ID", Kind: "type", Line: 11, Exported: true},
+				{Name: "run", Kind: "func", Line: 12, Exported: true},
+			},
+		},
+		{
+			filename: "sample.rb",
+			src:      "class User\nend\nmodule Tools\nend\nMAX = 1\ndef run\nend\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "Tools", Kind: "type", Line: 3, Exported: true},
+				{Name: "MAX", Kind: "const", Line: 5, Exported: true},
+				{Name: "run", Kind: "func", Line: 6, Exported: true},
+			},
+		},
+		{
+			filename: "sample.kt",
+			src:      "class User\ninterface Greeter\ntypealias ID = String\nval count = 1\nvar mutable = 2\nfun run() {}\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "Greeter", Kind: "type", Line: 2, Exported: true},
+				{Name: "ID", Kind: "type", Line: 3, Exported: true},
+				{Name: "count", Kind: "const", Line: 4, Exported: true},
+				{Name: "mutable", Kind: "var", Line: 5, Exported: true},
+				{Name: "run", Kind: "func", Line: 6, Exported: true},
+			},
+		},
+		{
+			filename: "sample.swift",
+			src:      "public class User {}\npublic struct Value {}\npublic enum Color { case red }\npublic protocol Greeter {}\npublic typealias ID = String\npublic let count = 1\nvar mutable = 2\npublic func run() {}\n",
+			want: []Symbol{
+				{Name: "User", Kind: "class", Line: 1, Exported: true},
+				{Name: "Value", Kind: "type", Line: 2, Exported: true},
+				{Name: "Color", Kind: "type", Line: 3, Exported: true},
+				{Name: "Greeter", Kind: "type", Line: 4, Exported: true},
+				{Name: "ID", Kind: "type", Line: 5, Exported: true},
+				{Name: "count", Kind: "const", Line: 6, Exported: true},
+				{Name: "mutable", Kind: "var", Line: 7},
+				{Name: "run", Kind: "func", Line: 8, Exported: true},
+			},
+		},
+		{
+			filename: "sample.zig",
+			src:      "pub const User = struct {};\nconst count = 1;\nvar mutable: u8 = 2;\npub fn run() void {}\n",
+			want: []Symbol{
+				{Name: "User", Kind: "type", Line: 1, Exported: true},
+				{Name: "count", Kind: "const", Line: 2},
+				{Name: "mutable", Kind: "var", Line: 3},
+				{Name: "run", Kind: "func", Line: 4, Exported: true},
+			},
+		},
+		{
+			filename: "sample.nim",
+			src:      "type\n  User* = object\nconst MAX* = 1\nvar mutable = 2\nlet fixed = 3\nproc run*() = discard\n",
+			want: []Symbol{
+				{Name: "User", Kind: "type", Line: 2, Exported: true},
+				{Name: "MAX", Kind: "const", Line: 3, Exported: true},
+				{Name: "mutable", Kind: "var", Line: 4},
+				{Name: "fixed", Kind: "const", Line: 5},
+				{Name: "run", Kind: "func", Line: 6, Exported: true},
+			},
+		},
+		{
+			filename: "sample.ex",
+			src:      "defmodule App do\nend\ndef run(), do: :ok\ndefp hidden(), do: :ok\n",
+			want: []Symbol{
+				{Name: "App", Kind: "type", Line: 1, Exported: true},
+				{Name: "run", Kind: "func", Line: 3, Exported: true},
+				{Name: "hidden", Kind: "func", Line: 4},
+			},
+		},
+		{
+			filename: "sample.erl",
+			src:      "-module(sample).\n-export([run/0]).\n-record(user, {name}).\n-type id() :: integer().\nrun() -> ok.\nhidden() -> ok.\n",
+			want: []Symbol{
+				{Name: "user", Kind: "type", Line: 3},
+				{Name: "id", Kind: "type", Line: 4},
+				{Name: "run", Kind: "func", Line: 5, Exported: true},
+				{Name: "hidden", Kind: "func", Line: 6},
+			},
+		},
+		{
+			filename: "sample.hs",
+			src:      "module Sample where\ndata User = User\ntype ID = Int\nrun x = pure x\nvalue = 1\n",
+			want: []Symbol{
+				{Name: "User", Kind: "type", Line: 2, Exported: true},
+				{Name: "ID", Kind: "type", Line: 3, Exported: true},
+				{Name: "run", Kind: "func", Line: 4, Exported: true},
+				{Name: "value", Kind: "var", Line: 5, Exported: true},
+			},
+		},
+		{
+			filename: "sample.clj",
+			src:      "(def MAX 1)\n(defn run [] 1)\n(defn- hidden [] 2)\n(defrecord User [])\n",
+			want: []Symbol{
+				{Name: "MAX", Kind: "var", Line: 1, Exported: true},
+				{Name: "run", Kind: "func", Line: 2, Exported: true},
+				{Name: "hidden", Kind: "func", Line: 3},
+				{Name: "User", Kind: "type", Line: 4, Exported: true},
+			},
+		},
+		{
+			filename: "sample.pm",
+			src:      "package Sample;\nsub run {}\n",
+			want:     []Symbol{{Name: "run", Kind: "func", Line: 2, Exported: true}},
+		},
+		{
+			filename: "sample.lua",
+			src:      "local value = 1\nfunction run() end\nlocal function hidden() end\n",
+			want: []Symbol{
+				{Name: "value", Kind: "var", Line: 1, Exported: true},
+				{Name: "run", Kind: "func", Line: 2, Exported: true},
+				{Name: "hidden", Kind: "func", Line: 3, Exported: true},
+			},
+		},
+		{
+			filename: "sample.R",
+			src:      "run <- function() {}\nvalue <- 1\n",
+			want: []Symbol{
+				{Name: "run", Kind: "func", Line: 1, Exported: true},
+				{Name: "value", Kind: "var", Line: 2, Exported: true},
+			},
+		},
+		{
+			filename: "sample.jl",
+			src:      "module Sample\nend\nexport User, run, MAX\nstruct User\nend\nabstract type Shape end\nprimitive type Byte 8 end\nconst MAX = 1\nfunction run()\nend\n",
+			want: []Symbol{
+				{Name: "Sample", Kind: "type", Line: 1},
+				{Name: "User", Kind: "type", Line: 4, Exported: true},
+				{Name: "Shape", Kind: "type", Line: 6},
+				{Name: "Byte", Kind: "type", Line: 7},
+				{Name: "MAX", Kind: "const", Line: 8, Exported: true},
+				{Name: "run", Kind: "func", Line: 9, Exported: true},
+			},
+		},
+		{
+			filename: "sample.ml",
+			src:      "module Sample = struct end\ntype user = { name: string }\nclass thing = object end\nlet run x = x\nlet value = 1\n",
+			want: []Symbol{
+				{Name: "Sample", Kind: "type", Line: 1, Exported: true},
+				{Name: "user", Kind: "type", Line: 2, Exported: true},
+				{Name: "thing", Kind: "class", Line: 3, Exported: true},
+				{Name: "run", Kind: "func", Line: 4, Exported: true},
+				{Name: "value", Kind: "var", Line: 5, Exported: true},
+			},
+		},
+		{
+			filename: "sample.fs",
+			src:      "module Sample\ntype User = { Name: string }\nlet run x = x\nlet value = 1\n",
+			want: []Symbol{
+				{Name: "Sample", Kind: "type", Line: 1, Exported: true},
+				{Name: "User", Kind: "type", Line: 2, Exported: true},
+				{Name: "run", Kind: "func", Line: 3, Exported: true},
+				{Name: "value", Kind: "var", Line: 4, Exported: true},
+			},
+		},
+		{
+			filename: "main.tf",
+			src:      "variable \"name\" {}\nresource \"thing\" \"web\" {}\nmodule \"vpc\" {}\n",
+			want: []Symbol{
+				{Name: "name", Kind: "var", Line: 1, Exported: true},
+				{Name: "web", Kind: "type", Line: 2, Exported: true},
+				{Name: "vpc", Kind: "type", Line: 3, Exported: true},
+			},
+		},
+		{
+			filename: "BUILD.bazel",
+			src:      "MAX = 1\ndef run():\n    pass\n",
+			want: []Symbol{
+				{Name: "MAX", Kind: "var", Line: 1, Exported: true},
+				{Name: "run", Kind: "func", Line: 2, Exported: true},
+			},
+		},
+		{
+			filename: "Makefile",
+			src:      "VALUE = 1\nall: build\nbuild:\n\t@true\n",
+			want: []Symbol{
+				{Name: "VALUE", Kind: "var", Line: 1, Exported: true},
+				{Name: "all", Kind: "func", Line: 2, Exported: true},
+				{Name: "build", Kind: "func", Line: 3, Exported: true},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.filename, func(t *testing.T) {
+			if got := symbolsFor(t, tc.filename, tc.src); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("symbols = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add top-level declaration metadata to outlined files without parsing source a second time. Each outlined `File` now includes ordered `Symbol` values with a name, kind, one-based line, and language-aware export status.

Standard symbol captures cover every existing language query, including Go capitalization, JavaScript and TypeScript exports and CommonJS assignments, and Python underscore visibility.