### PR TITLE
Fix Go and Ruby reference extraction

### DIFF
--- a/ref.go
+++ b/ref.go
@@ -22,7 +22,7 @@ func Refs(src []byte, filename string, receivers []string) ([]Ref, bool) {
 	var refs []Ref
 	switch l.name {
 	case "go":
-		refs = memberRefs(src, l.language, tree.RootNode(), wanted, "selector_expression", "field", "identifier")
+		refs = goRefs(src, l.language, tree.RootNode(), wanted)
 	case "ruby":
 		refs = rubyRefs(src, l.language, tree.RootNode(), wanted)
 	case "python":

--- a/ref_hyrum.go
+++ b/ref_hyrum.go
@@ -8,17 +8,35 @@ import (
 
 // goRefs matches package selectors in both value and type position:
 // selector_expression covers `pkg.Func()` and `pkg.Var`, qualified_type
-// covers `pkg.Type{}` and `var x pkg.Type`.
+// covers `pkg.Type{}` and `var x pkg.Type`. A single walk keeps results in
+// source order.
 func goRefs(src []byte, language *ts.Language, root *ts.Node, wanted map[string]bool) []Ref {
-	selectors := memberRefsWithFields(
-		src, language, root, wanted,
-		"selector_expression", "operand", "field", "identifier",
-	)
-	types := memberRefsWithFields(
-		src, language, root, wanted,
-		"qualified_type", "package", "name", "package_identifier",
-	)
-	return append(selectors, types...)
+	var refs []Ref
+	walkNamed(root, func(node *ts.Node) {
+		var receiver, member *ts.Node
+		switch node.Type(language) {
+		case "selector_expression":
+			receiver = node.ChildByFieldName("operand", language)
+			member = node.ChildByFieldName("field", language)
+			if receiver == nil || receiver.Type(language) != "identifier" {
+				return
+			}
+		case "qualified_type":
+			receiver = node.ChildByFieldName("package", language)
+			member = node.ChildByFieldName("name", language)
+		default:
+			return
+		}
+		if receiver == nil || member == nil || !wanted[receiver.Text(src)] {
+			return
+		}
+		refs = append(refs, Ref{
+			Receiver: receiver.Text(src),
+			Member:   member.Text(src),
+			Line:     sourceLine(member),
+		})
+	})
+	return refs
 }
 
 func rubyRefs(src []byte, language *ts.Language, root *ts.Node, wanted map[string]bool) []Ref {

--- a/ref_hyrum.go
+++ b/ref_hyrum.go
@@ -6,6 +6,21 @@ import (
 	ts "github.com/odvcencio/gotreesitter"
 )
 
+// goRefs matches package selectors in both value and type position:
+// selector_expression covers `pkg.Func()` and `pkg.Var`, qualified_type
+// covers `pkg.Type{}` and `var x pkg.Type`.
+func goRefs(src []byte, language *ts.Language, root *ts.Node, wanted map[string]bool) []Ref {
+	selectors := memberRefsWithFields(
+		src, language, root, wanted,
+		"selector_expression", "operand", "field", "identifier",
+	)
+	types := memberRefsWithFields(
+		src, language, root, wanted,
+		"qualified_type", "package", "name", "package_identifier",
+	)
+	return append(selectors, types...)
+}
+
 func rubyRefs(src []byte, language *ts.Language, root *ts.Node, wanted map[string]bool) []Ref {
 	var refs []Ref
 	walkNamed(root, func(node *ts.Node) {
@@ -17,11 +32,14 @@ func rubyRefs(src []byte, language *ts.Language, root *ts.Node, wanted map[strin
 		switch node.Type(language) {
 		case "scope_resolution":
 			receiver = node.NamedChild(0)
-			member = node.NamedChild(node.NamedChildCount() - 1)
+			member = node.ChildByFieldName("name", language)
 		case "call":
-			if node.NamedChild(0).Type(language) == "constant" {
-				receiver = node.NamedChild(0)
-				member = node.NamedChild(node.NamedChildCount() - 1)
+			// The last named child of a call may be an argument list or a
+			// block; the method identifier is the named `method` field.
+			receiver = node.ChildByFieldName("receiver", language)
+			member = node.ChildByFieldName("method", language)
+			if receiver == nil || receiver.Type(language) != "constant" {
+				return
 			}
 		}
 		if receiver == nil || member == nil || !wanted[receiver.Text(src)] {

--- a/ref_test.go
+++ b/ref_test.go
@@ -88,18 +88,26 @@ func TestHyrumLanguageRefs(t *testing.T) {
 		want      []Ref
 	}{
 		{
-			filename:  "main.go",
-			src:       "package main\nfunc f() { alias.Member(); other.Member() }\n",
+			filename: "main.go",
+			src: "package main\nfunc f() { alias.Member(); other.Member() }\n" +
+				"var v alias.Type = alias.Type{}\n",
 			receivers: []string{"alias"},
-			want:      []Ref{{Receiver: "alias", Member: "Member", Line: 2}},
+			want: []Ref{
+				{Receiver: "alias", Member: "Member", Line: 2},
+				{Receiver: "alias", Member: "Type", Line: 3},
+				{Receiver: "alias", Member: "Type", Line: 3},
+			},
 		},
 		{
-			filename:  "app.rb",
-			src:       "Octokit::Client.new\nOctokit.configure\nOther::Client.new\n",
+			filename: "app.rb",
+			src: "Octokit::Client.new\nOctokit.configure\n" +
+				"Octokit.middleware(x, y) { |c| c.use Other }\n" +
+				"Other::Client.new\n",
 			receivers: []string{"Octokit"},
 			want: []Ref{
 				{Receiver: "Octokit", Member: "Client", Line: 1},
 				{Receiver: "Octokit", Member: "configure", Line: 2},
+				{Receiver: "Octokit", Member: "middleware", Line: 3},
 			},
 		},
 		{

--- a/ref_test.go
+++ b/ref_test.go
@@ -89,13 +89,13 @@ func TestHyrumLanguageRefs(t *testing.T) {
 	}{
 		{
 			filename: "main.go",
-			src: "package main\nfunc f() { alias.Member(); other.Member() }\n" +
-				"var v alias.Type = alias.Type{}\n",
+			src: "package main\nvar v alias.Type = alias.Type{}\n" +
+				"func f() { alias.Member(); other.Member() }\n",
 			receivers: []string{"alias"},
 			want: []Ref{
-				{Receiver: "alias", Member: "Member", Line: 2},
-				{Receiver: "alias", Member: "Type", Line: 3},
-				{Receiver: "alias", Member: "Type", Line: 3},
+				{Receiver: "alias", Member: "Type", Line: 2},
+				{Receiver: "alias", Member: "Type", Line: 2},
+				{Receiver: "alias", Member: "Member", Line: 3},
 			},
 		},
 		{


### PR DESCRIPTION
Two fixes surfaced while wiring `Refs` into hyrum's usage indexer.

Go: `Refs` only matched `selector_expression`, so type-position package references were missed. `sse.Event{}` and `var e sse.Event` both parse as `qualified_type` (fields `package`/`name`), not `selector_expression`. This adds a second match on `qualified_type` and also switches `selector_expression` to its actual `operand` receiver field instead of the `object` default that only worked via the `NamedChild(0)` fallback.

Ruby: `rubyRefs` took the last named child of a `call` node as the member. When the call has a block or argument list, that is the last child, so `Octokit.configure { |c| ... }` reported the block text as the member. Now uses `ChildByFieldName("method")` and `ChildByFieldName("receiver")`.

Regression cases added to `TestHyrumLanguageRefs`.